### PR TITLE
Updated error catching and informative messages

### DIFF
--- a/R/applyClipping.R
+++ b/R/applyClipping.R
@@ -20,8 +20,6 @@
 applyClipping <- function(data, parallel = TRUE, clipBy = "group") {
   # parallel argument currently not used
   
-  data(speciesInfo)
-  
   if (clipBy == "group" | data$clipBy != "species") { 
     # check that this arrangement makes sense
     # I think it's ok, given only two possibilities. Group overrides......
@@ -29,13 +27,6 @@ applyClipping <- function(data, parallel = TRUE, clipBy = "group") {
     data$meta[,4] <- max(data$meta[,4])
     
     }
-
-  ## select which species to drop based on scheme advice etc. These are removed by stackFilter
-  
-  drop <- which(!is.na(speciesInfo$Reason_not_included) & speciesInfo$Reason_not_included != "Didn't meet criteria")
-  
-  drop <- c(as.character(speciesInfo$Species[drop]), 
-            as.character(speciesInfo$concept[drop]))
   
   stacked_samps <- tempStackFilter(input = "memory",
                                    dat = data$samp_post,

--- a/R/applyFilters.R
+++ b/R/applyFilters.R
@@ -38,14 +38,26 @@ applyFilters <- function(roster, parallel = TRUE) {
   } else {
     
     modFilePath <- file.path(roster$modPath, roster$group, "occmod_outputs", roster$ver)
-    modFiles <- list.files(modFilePath)
     
-    # read the suffix of the first model files
-    filetype <- strsplit(modFiles[1], "\\.")[[1]][2] 
-    if(!filetype %in% c("rdata", "rds")) stop("Model files must be either .rds or .rdata")
+    # try .rdata
+    modFiles_rdata <- list.files(modFilePath, pattern = ".rdata")
     
-    # strip out the files
-    modFiles <- modFiles[grepl(paste0(filetype, "$"), modFiles)] # dollar sign ensures the filetype suffix is at end of name
+    # try .rds
+    modFiles_rds <- list.files(modFilePath, pattern = ".rds")
+    
+    if (length(modFiles_rdata) == 0 & length(modFiles_rds) == 0) 
+      stop("Model files must be either .rds or .rdata")
+    
+    else {
+      
+      if(length(modFiles_rdata) == 0) {
+        filetype <- "rds"
+        modFiles <- modFiles_rds}
+      else {
+        filetype <- "rdata"
+        modFiles <- modFiles_rdata}
+      
+    }
     
     # retain the species names (with iteration number if applicable - chained models)
     keep_iter <- gsub(pattern = paste0("\\.", filetype), repl = "", modFiles)

--- a/R/applyFilters.R
+++ b/R/applyFilters.R
@@ -47,7 +47,7 @@ applyFilters <- function(roster, parallel = TRUE) {
     # strip out the files
     modFiles <- modFiles[grepl(paste0(filetype, "$"), modFiles)] # dollar sign ensures the filetype suffix is at end of name
     
-    # retain the species names (with iteration number if applicable)
+    # retain the species names (with iteration number if applicable - chained models)
     keep_iter <- gsub(pattern = paste0("\\.", filetype), repl = "", modFiles)
   }
   
@@ -63,7 +63,7 @@ applyFilters <- function(roster, parallel = TRUE) {
     
   } else {
     
-    # species names don't have associated iteration numbers
+    # species names don't have associated iteration numbers - non-chained models
     keep <- keep_iter
     
     keep_iter <- NULL
@@ -73,7 +73,7 @@ applyFilters <- function(roster, parallel = TRUE) {
   # Subset to speciesToKeep
   if(!is.na(roster$speciesToKeep)){
     
-    # Convert the comma seperated species names to a vector of species
+    # Convert the comma separated species names to a vector of species
     speciesToKeep <- unlist(strsplit(roster$speciesToKeep, ','))
     
     # Species not found

--- a/R/applyFilters.R
+++ b/R/applyFilters.R
@@ -111,7 +111,7 @@ applyFilters <- function(roster, parallel = TRUE) {
               as.character(speciesInfo$concept[drop]))
     
     # only keep species as advised
-    keep <- keep[keep != drop]
+    keep <- keep[!keep %in% drop]
   }
   
   out <- tempSampPost(indata = paste0(roster$modPath, roster$group, "/occmod_outputs/", roster$ver, "/"),

--- a/R/applyFilters.R
+++ b/R/applyFilters.R
@@ -100,7 +100,20 @@ applyFilters <- function(roster, parallel = TRUE) {
     keep <- keep[tolower(keep) %in% tolower(speciesToKeep)]
     
   }
-
+  
+  if(roster$drop == TRUE) {
+    
+    ## select which species to drop based on scheme advice etc. These are removed by stackFilter
+  
+    drop <- which(!is.na(speciesInfo$Reason_not_included) & speciesInfo$Reason_not_included != "Didn't meet criteria")
+  
+    drop <- c(as.character(speciesInfo$Species[drop]), 
+              as.character(speciesInfo$concept[drop]))
+    
+    # only keep species as advised
+    keep <- keep[keep != drop]
+  }
+  
   out <- tempSampPost(indata = paste0(roster$modPath, roster$group, "/occmod_outputs/", roster$ver, "/"),
                       keep = keep,
                       keep_iter = keep_iter,
@@ -131,13 +144,6 @@ applyFilters <- function(roster, parallel = TRUE) {
     meta[,3] <- min(meta[,3])
     meta[,4] <- max(meta[,4])
   }
-
-  ## select which species to drop based on scheme advice etc. These are removed by stackFilter
-  
-  drop <- which(!is.na(speciesInfo$Reason_not_included) & speciesInfo$Reason_not_included != "Didn't meet criteria")
-  
-  drop <- c(as.character(speciesInfo$Species[drop]), 
-            as.character(speciesInfo$concept[drop]))
   
   stacked_samps <- tempStackFilter(input = "memory",
                                    dat = samp_post,

--- a/R/applySamp.R
+++ b/R/applySamp.R
@@ -92,6 +92,19 @@ applySamp <- function(roster, parallel = TRUE, sample = TRUE) {
     
   }
   
+  if(roster$drop == TRUE) {
+    
+    ## select which species to drop based on scheme advice etc. These are removed by stackFilter
+    
+    drop <- which(!is.na(speciesInfo$Reason_not_included) & speciesInfo$Reason_not_included != "Didn't meet criteria")
+    
+    drop <- c(as.character(speciesInfo$Species[drop]), 
+              as.character(speciesInfo$concept[drop]))
+    
+    # only keep species as advised
+    keep <- keep[keep != drop]
+  }
+  
   if(sample == TRUE)
     out <- tempSampPost(indata = paste0(roster$modPath, roster$group, "/occmod_outputs/", roster$ver, "/"),
                         keep = keep,
@@ -105,6 +118,7 @@ applySamp <- function(roster, parallel = TRUE, sample = TRUE) {
                         #min_year_model = 1970,
                         write = FALSE,
                         minObs = roster$minObs,
+                        scaleObs = roster$scaleObs,
                         t0 = roster$t0,
                         tn = roster$tn,
                         parallel = parallel,
@@ -128,6 +142,15 @@ applySamp <- function(roster, parallel = TRUE, sample = TRUE) {
   meta <- out[[2]]
   
   meta[ ,1] <- tolower(meta[, 1])
+  
+  if (roster$write == TRUE) {
+    
+    comb <- list(samp_post, meta)
+    
+    save(comb, file = paste0(roster$outPath, roster$group, "_", roster$indicator, 
+                                      "_", roster$region, "_samp.rdata"))
+    
+  }
   
   return(list(samp_post = samp_post, 
               meta = meta,

--- a/R/applySamp.R
+++ b/R/applySamp.R
@@ -102,7 +102,7 @@ applySamp <- function(roster, parallel = TRUE, sample = TRUE) {
               as.character(speciesInfo$concept[drop]))
     
     # only keep species as advised
-    keep <- keep[keep != drop]
+    keep <- keep[!keep %in% drop]
   }
   
   if(sample == TRUE)

--- a/R/applySamp.R
+++ b/R/applySamp.R
@@ -29,20 +29,31 @@ applySamp <- function(roster, parallel = TRUE, sample = TRUE) {
   } else {
     
     modFilePath <- file.path(roster$modPath, roster$group, "occmod_outputs", roster$ver)
-    modFiles <- list.files(modFilePath)
     
-    # read the suffix of the first model files
-    filetype <- strsplit(modFiles[1], "\\.")[[1]][2] 
-    if(!filetype %in% c("rdata", "rds")) stop("Model files must be either .rds or .rdata")
+    # try .rdata
+    modFiles_rdata <- list.files(modFilePath, pattern = ".rdata")
     
-    # strip out the files
-    modFiles <- modFiles[grepl(paste0(filetype, "$"), modFiles)] # dollar sign ensures the filetype suffix is at end of name
+    # try .rds
+    modFiles_rds <- list.files(modFilePath, pattern = ".rds")
     
-    # retain the species names (with iteration number if applicable)
+    if (length(modFiles_rdata) == 0 & length(modFiles_rds) == 0) 
+      stop("Model files must be either .rds or .rdata")
+    
+    else {
+      
+      if(length(modFiles_rdata) == 0) {
+        filetype <- "rds"
+        modFiles <- modFiles_rds}
+      else {
+        filetype <- "rdata"
+        modFiles <- modFiles_rdata}
+      
+    }
+    
+    # retain the species names (with iteration number if applicable - chained models)
     keep_iter <- gsub(pattern = paste0("\\.", filetype), repl = "", modFiles)
   }
   
-  # first species
   first_spp <- keep_iter[[1]]
   
   # test if first species is chained (i.e., JASMIN models)
@@ -55,10 +66,29 @@ applySamp <- function(roster, parallel = TRUE, sample = TRUE) {
     
   } else {
     
-    # species names don't have associated iteration numbers
+    # species names don't have associated iteration numbers - non-chained models
     keep <- keep_iter
     
     keep_iter <- NULL
+    
+  }
+  
+  # Subset to speciesToKeep
+  if(!is.na(roster$speciesToKeep)){
+    
+    # Convert the comma separated species names to a vector of species
+    speciesToKeep <- unlist(strsplit(roster$speciesToKeep, ','))
+    
+    # Species not found
+    notFound <- speciesToKeep[!tolower(speciesToKeep) %in% tolower(keep)]
+    
+    if(length(notFound) > 0){
+      warning(paste('some species on your "speciesToKeep" list were not found in the data:',
+                    paste(notFound, collapse = ', ')))
+    }
+    
+    # Subset keep
+    keep <- keep[tolower(keep) %in% tolower(speciesToKeep)]
     
   }
   

--- a/R/calcMSI.R
+++ b/R/calcMSI.R
@@ -93,7 +93,7 @@ calcMSI <- function(dat,
     
     getSumStats <- function(stat) {
       
-      out <- reshape2::melt(out, 
+      out <- reshape2::melt(stat, 
                   id.vars = "species",
                   variable.name = "year",
                   value.name = "index")

--- a/R/calcMSI.R
+++ b/R/calcMSI.R
@@ -109,6 +109,9 @@ calcMSI <- function(dat,
     inDat <- data.frame(means, 
                         se = se)
     
+    # prevent Error in node tau.obs when se = 0
+    inDat$se[inDat$se == 0] <- 0.0001
+    
     inDat$year <- as.numeric(gsub("year_", "", inDat$year))
     
     ind <- BRCindicators::bma(data = inDat,

--- a/R/createRoster.R
+++ b/R/createRoster.R
@@ -55,7 +55,7 @@
 #'                
 #' @param speciesToKeep A character vector of strings. the names of species to
 #' include, this is used in combination with 'indicator'. ONLY species on both
-#' lists will be included on the output.
+#' lists will be included in the output.
 #'  	  
 #' @param clipBy A character string or vector of strings. One of "species" or 
 #'               "group" indicating whether to clip outputs by the first and 

--- a/R/createRoster.R
+++ b/R/createRoster.R
@@ -56,6 +56,9 @@
 #' @param speciesToKeep A character vector of strings. the names of species to
 #' include, this is used in combination with 'indicator'. ONLY species on both
 #' lists will be included in the output.
+#' 
+#' @param drop Logical or logical vector. If TRUE then species are dropped
+#'             based on scheme advice complied by Charlie Outhwaite
 #'  	  
 #' @param clipBy A character string or vector of strings. One of "species" or 
 #'               "group" indicating whether to clip outputs by the first and 
@@ -82,6 +85,7 @@ createRoster <- function(index,
                          write,
                          outPath,
                          speciesToKeep = NA,
+                         drop = TRUE,
                          clipBy = "group",
                          t0,
                          tn) {
@@ -131,6 +135,7 @@ createRoster <- function(index,
                    speciesToKeep = ifelse(test = is.na(speciesToKeep), 
                                           yes = NA, 
                                           no = as.character(paste(speciesToKeep, collapse = ','))),
+                   drop = drop,
                    clipBy = clipBy,
                    t0 = t0,
                    tn = tn,

--- a/R/tempSampPost.R
+++ b/R/tempSampPost.R
@@ -144,11 +144,11 @@ tempSampPost <- function(indata = "../data/model_runs/",
         out_dat2 <- NULL
         out_dat3 <- NULL
         
-        out_dat1 <- try(load_rdata(paste0(indata, species, "_20000_1.rdata"))) # where occupancy data is stored for JASMIN models 
+        try(out_dat1 <- load_rdata(paste0(indata, species, "_20000_1.rdata"))) # where occupancy data is stored for JASMIN models 
         raw_occ1 <- data.frame(out_dat1$BUGSoutput$sims.list[REGION_IN_Q])
-        out_dat2 <- try(load_rdata(paste0(indata, species, "_20000_2.rdata"))) # where occupancy data is stored for JASMIN models 
+        try(out_dat2 <- load_rdata(paste0(indata, species, "_20000_2.rdata"))) # where occupancy data is stored for JASMIN models 
         raw_occ2 <- data.frame(out_dat2$BUGSoutput$sims.list[REGION_IN_Q])
-        out_dat3 <- try(load_rdata(paste0(indata, species, "_20000_3.rdata"))) # where occupancy data is stored for JASMIN models 
+        try(out_dat3 <- load_rdata(paste0(indata, species, "_20000_3.rdata"))) # where occupancy data is stored for JASMIN models 
         raw_occ3 <- data.frame(out_dat3$BUGSoutput$sims.list[REGION_IN_Q])
         
         if(!is.null(out_dat1) & !is.null(out_dat2) & !is.null(out_dat3)) # if all models loaded correctly

--- a/R/tempSampPost.R
+++ b/R/tempSampPost.R
@@ -250,7 +250,7 @@ tempSampPost <- function(indata = "../data/model_runs/",
       # informative messages
       if(!is.na(nRec) & !nRec >= minObs) 
         print(paste("Dropped (lack of observations):", species)) 
-      else if(!REGION_IN_Q %in% paste0("psi.fs.r_", out_meta$regions))
+      else if(!is.na(nRec) & !REGION_IN_Q %in% paste0("psi.fs.r_", out_meta$regions))
         print(paste("Dropped (no regional occupancy estimate):", species))
       else print(paste("Error loading model:", species))
       

--- a/R/tempSampPost.R
+++ b/R/tempSampPost.R
@@ -84,8 +84,7 @@ tempSampPost <- function(indata = "../data/model_runs/",
       
       # chained models
       try(out_dat <- load_rdata(paste0(indata, species, "_20000_1.rdata")))  # where the first part of the model is stored for JASMIN models
-      if(!is.null(out_dat$model)) # if model exists
-        out_meta <- load_rdata(paste0(indata, species, "_", min_iter, "_1.rdata")) # where metadata is stored for JASMIN models
+      try(out_meta <- load_rdata(paste0(indata, species, "_", min_iter, "_1.rdata"))) # where metadata is stored for JASMIN models
 
       } else {
       
@@ -107,7 +106,7 @@ tempSampPost <- function(indata = "../data/model_runs/",
       
       }
     
-    if(!is.null(out_dat$model)) { # there is a model object to read from
+    if(!is.null(out_dat$model) & !is.null(out_meta)) { # there is a model object to read from with metadata
       
       if(scaleObs == "global") # global scale evaluation
       

--- a/R/tempSampPost.R
+++ b/R/tempSampPost.R
@@ -248,7 +248,7 @@ tempSampPost <- function(indata = "../data/model_runs/",
     } else {
       
       # informative messages
-      if(!nRec >= minObs) 
+      if(!is.na(nRec) & !nRec >= minObs) 
         print(paste("Dropped (lack of observations):", species)) 
       else if(!REGION_IN_Q %in% paste0("psi.fs.r_", out_meta$regions))
         print(paste("Dropped (no regional occupancy estimate):", species))

--- a/R/tempSampPost.R
+++ b/R/tempSampPost.R
@@ -256,6 +256,7 @@ tempSampPost <- function(indata = "../data/model_runs/",
       else print(paste("Error loading model:", species))
       
       return(NULL)
+    }
   }
   
   if(parallel) outputs <- parallel::mclapply(keep, mc.cores = n.cores,

--- a/R/tempSampPost.R
+++ b/R/tempSampPost.R
@@ -177,14 +177,14 @@ tempSampPost <- function(indata = "../data/model_runs/",
 
         }
       
-        if(diff > tolerance){
+        if(diff > tolerance) {
         
           # we have more sims in the model than we want, so we need to sample them
           raw_occ <- raw_occ[sample(1:nrow(raw_occ), sample_n), ]
         
         } else 
         
-          if(abs(diff) <= tolerance){
+          if(abs(diff) <= tolerance) {
             # The number of sims is very close to the target, so no need to sample
             print(paste("no sampling required: n.sims =", out_dat$BUGSoutput$n.sims))
           
@@ -240,12 +240,22 @@ tempSampPost <- function(indata = "../data/model_runs/",
       
       } else {
       
-        print(paste("Dropped:", species))
+        print(paste("Error loading model:", species)) # this can happen for JASMIN models if one of the models in the chain doesn't load properly
       
         return(NULL)
       
       }
-    }
+      
+    } else {
+      
+      # informative messages
+      if(!nRec >= minObs) 
+        print(paste("Dropped (lack of observations):", species)) 
+      else if(!REGION_IN_Q %in% paste0("psi.fs.r_", out_meta$regions))
+        print(paste("Dropped (no regional occupancy estimate):", species))
+      else print(paste("Error loading model:", species))
+      
+      return(NULL)
   }
   
   if(parallel) outputs <- parallel::mclapply(keep, mc.cores = n.cores,

--- a/R/tempSampPost.R
+++ b/R/tempSampPost.R
@@ -14,7 +14,7 @@ tempSampPost <- function(indata = "../data/model_runs/",
                          output_path = "../data/sampled_posterior_1000/",
                          region,
                          sample_n = 999,
-                         tolerance = 3, # number of iterations above or below sample_n to be acceptable
+                         tolerance = 0, # number of iterations above or below sample_n to be acceptable
                          group_name = "",
                          combined_output = TRUE,
                          max_year_model = NULL, 

--- a/R/tempSampPost.R
+++ b/R/tempSampPost.R
@@ -107,20 +107,28 @@ tempSampPost <- function(indata = "../data/model_runs/",
       
       if(scaleObs == "global") # global scale evaluation
       
-      nRec <- out_meta$species_observations # total number of observations for species
+        # HOW COULD WE MAKE THIS TEMPORALLY EXPLICIT?
+        nRec <- out_meta$species_observations # total number of observations for species
       
       else {
+        
+        dat <- out_meta$model$data() # retrieve input data
       
-      dat <- out_meta$model$data() # retrieve input data
-      
-      nRec <- sum(dat$y * dat[[paste0("r_", region)]][dat$Site]) # number of observations within region
+        dat <- data.frame(year = dat$Year, # year
+                          rec = dat$y, # records
+                          region_site = dat[[paste0("r_", region)]][dat$Site]) # sites within selected region
+        
+        # subset to region and temporal window
+        dat <- dat[dat$region_site == 1 & dat$year >= (t0 - (out_meta$min_year - 1)) & dat$year <= (tn - (out_meta$min_year - 1)), ]
+        
+        nRec <- sum(dat$rec) # number of observations within region within time window t0 - tn
       
       }
     } else nrec <- NA # null models get NA observations
     
     print(paste0("load: ", species, ", ", scaleObs, " records: ", nRec))
     
-    if(nRec >= minObs & # there are enough observations globally (or in region?)
+    if(nRec >= minObs & # there are enough observations globally or in region
        REGION_IN_Q %in% paste0("psi.fs.r_", out_meta$regions) & # the species has data in the region of interest 
        !is.null(out_dat$model) # there is a model object to read from
        ) { # three conditions are met


### PR DESCRIPTION
I have restructured some of the code, included more `if` statements and used `try` to catch and pass errors and return the reason why a species has been dropped.

Major changes:
- Evaluation of `minObs` is now possible at the global or regional scale (using the `scaleObs` parameter in `createRoster`)
- Evaluation of `minObs` is now temporally explicit for the regional scale based on `t0` and `tn`
- Reading in of species names in `applyFilters` now uses `pattern` to check for .rdata or .rds files, so that if other files, e.g., console_output.txt are present it won't break
- I've used `try` every time files are accessed in `tempSampPost` with default NULL, this means that if part of a species data is broken (e.g., the metadata or one file in the JASMIN chains) then an error will be returned but the process will continue
- I've changed the messages returned so that they are informative, e.g., "Dropped (lack of observations): species", "Error loading model: species"